### PR TITLE
Feat: 로그인, 회원가입 페이지 UI 작업

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,0 +1,19 @@
+import AuthSection from "@/app/ui/sign/auth-section";
+import HeaderSection from "@/app/ui/sign/header-section";
+
+function LoginPage() {
+  return (
+    <div className="flex h-screen flex-col items-center justify-center gap-30">
+      <HeaderSection title={"로그인"} />
+
+      <AuthSection
+        title={"로그인"}
+        message={"계정이 없으신가요?"}
+        linkLabel={"회원가입"}
+        linkHref={"/signup"}
+      ></AuthSection>
+    </div>
+  );
+}
+
+export default LoginPage;

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -1,0 +1,19 @@
+import AuthSection from "@/app/ui/sign/auth-section";
+import HeaderSection from "@/app/ui/sign/header-section";
+
+function SignupPage() {
+  return (
+    <div className="flex h-screen flex-col items-center justify-center gap-20">
+      <HeaderSection title={"회원가입"} />
+
+      <AuthSection
+        title={"회원가입"}
+        message={"계정이 있으신가요?"}
+        linkLabel={"로그인"}
+        linkHref={"/login"}
+      ></AuthSection>
+    </div>
+  );
+}
+
+export default SignupPage;

--- a/src/app/ui/common/button.tsx
+++ b/src/app/ui/common/button.tsx
@@ -3,6 +3,12 @@ import { Slot } from "@radix-ui/react-slot";
 import { cva, type VariantProps } from "class-variance-authority";
 
 import { cn } from "@/lib/utils";
+import Link from "next/link";
+
+type TextButtonProps = {
+  href: string;
+  children: string;
+};
 
 const buttonVariants = cva(
   "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
@@ -56,4 +62,12 @@ function Button({
   );
 }
 
-export { Button, buttonVariants };
+function TextButton({ href, children }: TextButtonProps) {
+  return (
+    <Link href={href} className={`text-blue-600`}>
+      {children}
+    </Link>
+  );
+}
+
+export { Button, buttonVariants, TextButton };

--- a/src/app/ui/sign/auth-section.tsx
+++ b/src/app/ui/sign/auth-section.tsx
@@ -1,0 +1,27 @@
+import { Button, TextButton } from "@/app/ui/common/button";
+
+type AuthSectionProps = {
+  title: string;
+  message: string;
+  linkLabel: string;
+  linkHref: string;
+};
+
+function AuthSection({
+  title,
+  message,
+  linkLabel,
+  linkHref,
+}: AuthSectionProps) {
+  return (
+    <div className="grid gap-5">
+      <Button className="p-5 text-2xl">GitHub로 {title}</Button>
+
+      <div className="flex justify-center gap-3">
+        {message} <TextButton href={linkHref}>{linkLabel}</TextButton>
+      </div>
+    </div>
+  );
+}
+
+export default AuthSection;

--- a/src/app/ui/sign/header-section.tsx
+++ b/src/app/ui/sign/header-section.tsx
@@ -1,0 +1,15 @@
+import Header from "@/app/ui/common/header";
+
+type HeaderProps = {
+  title: string;
+};
+
+function HeaderSection({ title }: HeaderProps) {
+  return (
+    <div className="fixed top-0 text-center">
+      <Header>ssakssak commit</Header>
+      <p>{title}</p>
+    </div>
+  );
+}
+export default HeaderSection;


### PR DESCRIPTION
## 📝 요약(Summary)
- 로그인 페이지와 회원 가입 페이지 UI를 구현
- [로그인 페이지] 계정이 없다면, 회원가입 페이지로 이동할 수 있게끔 `Text Button` 제공
- [회원가입 페이지] 계정이 있다면, 로그인 페이지로 이동할 수 있게끔 `Text Button` 제공


<br><br>


## ☑️ Task
### 공통
- `HeaderSection`과 `AuthSection`를 분리하여 페이지 구조를 명확히 구분하고자 했습니다
- 각 페이지에서 `HeaderSection`은 상단 타이틀 영역, `AuthSection`은 로그인/회원가입 등 본문을 담당하도록  담당하도록 나눠 가독성을 높였습니다
- `AuthSection`에 `title`, `message`, `linkLabel`, `linkHref`를 props로 전달할 수 있게 하여 로그인/회원가입 페이지 모두 재사용 가능하도록 구성했습니다


### 로그인 페이지
- [x] 로그인 페이지 구현
- [x] 로그인 페이지에서 '회원 가입' 텍스트 버튼 클릭 시, 회원 가입 페이지로 이동
<img width="371" height="807" alt="image" src="https://github.com/user-attachments/assets/8d5c747b-9144-417e-8488-d3efac1faf8f" />


<br><br>


### 회원 가입 페이지
- [x] 회원 가입 페이지 구현
- [x] 회원 가입 페이지에서 '로그인' 텍스트 버튼 클릭 시, 로그인 페이지로 이동

<img width="371" height="808" alt="image" src="https://github.com/user-attachments/assets/2fbd2bfc-fa64-4081-b4e0-75ed77886a53" />


<br><br>



<br><br>


## 💬 공유사항 to 리뷰어
- 컴포넌트 작업 도중, 타입 분류에 대해 생각해 보게 되었습니다!
- 타입을 분리하는 목적은 보기 좋게 정리하기 위해서가 아닌 **의도(사용 목적)를 명확히 하고, 타입을 공유하기 위해서** 라고 생각합니다. 이와 관련해 아래와 같이 정리해 보았습니다.

<br />


1. 로컬 vs 전역 기준

> 특정 컴포넌트 안에서만 쓰이는 타입이라면 **로컬**에 두고, 다른 컴포넌트나 파일에서 재사용될 경우에 별도의 type으로 분리하는 것이 적절할 것이라 판단. 이에 현재 컴포넌트 타입을 해당하는 파일 상에 타입을 분류했습니다.


2. [DRY 원칙](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself)

> DRY 원칙에 따라 **중복해서 쓰이는 타입이면 분리하고, 단일 사용이라면 같은 파일에 두는 편이 효율적**이라고 생각


3. 맥락 기반 위치 선정
> API에서 내려받는 응답 타입은 전역적으로 관리하는 반면, 컴포넌트의 props, state 같은 맥락 의존성이 큰 타입은 해당 컴포넌트 근처에 두는 것이 맥락상 자연스러움


4. 구현과의 결합도 고려
> 특정 로직과 강하게 결합된 타입은 오히려 분리하지 않고 파일에서 정의하는 게 유지보수 측면에서 타입을 수정할 때 곧바로 해당 구현 맥락에서 확인할 수 있음


참고 문헌: [typescript를 사용하여 타입을 구성하는 방법](https://stackoverflow.com/questions/62373473/how-to-organize-types-definitions-in-a-react-project-using-typescript)에 대해서 말하는 자료입니다!


<br><br>


## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
- [x] conflict를 모두 해결하였습니다.
- [x] 가장 최신 dev 브랜치를 pull 하였습니다.
- [x] 코드 컨벤션을 모두 확인하였습니다.
- [x] `console.log`나 주석 여부를 확인하였습니다.
- [x] 브랜치명을 확인하였습니다.
- [x] 작업 중 dependency 변경사항이 있는 경우 안내해주세요!
