### PR TITLE
Refactor: 리포트 생성 기능 server action 전환 및 리렌더링 최적화

### DIFF
--- a/src/app/(with-layout)/actions/submit-report-action.ts
+++ b/src/app/(with-layout)/actions/submit-report-action.ts
@@ -1,0 +1,61 @@
+"use server";
+
+import {
+  DATA_ERROR_MESSAGES,
+  SYSTEM_ERROR_MESSAGES,
+} from "@/constants/error-messages";
+import { ReportFormState } from "@/types/report";
+import { cookies } from "next/headers";
+import { redirect } from "next/navigation";
+
+export async function submitReportAction(
+  prevState: unknown,
+  formData: FormData,
+): Promise<ReportFormState> {
+  const body = {
+    reportTitle: String(formData.get("reportTitle") ?? "").trim(),
+    repositoryOverview: String(formData.get("repositoryOverview") ?? "").trim(),
+    repositoryUrl: String(formData.get("repositoryUrl") ?? "").trim(),
+    branch: String(formData.get("branch") ?? "").trim(),
+    reportHistoryId: formData.get("reportHistoryId")
+      ? String(formData.get("reportHistoryId"))
+      : null,
+  };
+
+  if (!body.repositoryUrl || !body.branch) {
+    return {
+      ok: false,
+      formError: "리포지토리 URL과 브랜치를 모두 선택해 주세요.",
+    };
+  }
+
+  const response = await fetch(`${process.env.NEXTAUTH_URL}/api/reports`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+    cache: "no-store",
+  });
+
+  const json = await response.json();
+
+  if (!response.ok) {
+    const message = json?.error?.message ?? DATA_ERROR_MESSAGES.READ;
+    return { ok: false, formError: message };
+  }
+
+  const jobId: string | undefined = json?.jobId;
+  if (!jobId) {
+    return { ok: false, formError: SYSTEM_ERROR_MESSAGES.UNKNOWN };
+  }
+
+  const cookieStore = await cookies();
+  cookieStore.set("jobId", jobId, {
+    path: "/loading",
+    httpOnly: true,
+    sameSite: "lax",
+    secure: true,
+    maxAge: 60 * 5,
+  });
+
+  redirect("/loading");
+}

--- a/src/app/ui/layout/layout-header.tsx
+++ b/src/app/ui/layout/layout-header.tsx
@@ -3,11 +3,11 @@ function LayoutHeader() {
     <div className="flex flex-col items-center justify-center">
       <div className="py-2 pr-12 text-[40px] font-bold">🧹싹싹커밋</div>
       <div className="text-center">
-        <span className="text-gray-400">복잡한 커밋을 </span>
-        <span className="text-yellow-500">싹싹</span>
-        <span className="text-gray-400">
-          모아서 한 눈에 이해할 수 있게 도와드립니다
-        </span>
+        <span className="text-gray-400">복잡한 커밋을</span>
+        <span className="text-yellow-500"> 싹싹 </span>
+        <span className="text-gray-400">모아서 한 눈에 이해할 수 있게</span>
+        <span className="text-yellow-500"> 리포트</span>
+        <span className="text-gray-400">로 만들어 드립니다</span>
       </div>
     </div>
   );

--- a/src/app/ui/main/report-form.tsx
+++ b/src/app/ui/main/report-form.tsx
@@ -1,169 +1,68 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useActionState } from "react";
 import { InputField } from "@/app/ui/common/input";
 import { Label } from "@/app/ui/common/label";
 import { Textarea } from "@/app/ui/common/textarea";
-import { Button } from "@/app/ui/common/button";
 import RepositoryBranchSelector from "@/app/ui/main/repository-branch-selector";
 import ErrorMessage from "@/app/ui/common/error-message";
-import {
-  SYSTEM_ERROR_MESSAGES,
-  VALIDATION_ERROR_MESSAGES,
-} from "@/constants/error-messages";
-import { useRouter } from "next/navigation";
 import { useReportHistory } from "@/hooks/useVerifiedContext";
-import handleApiError from "@/lib/handle-api-error";
-import { AlertModal } from "@/app/ui/common/Modal";
+import { submitReportAction } from "@/app/(with-layout)/actions/submit-report-action";
+import SubmitButton from "@/app/ui/main/submit-button";
+import { ReportFormState } from "@/types/report";
 
 function ReportForm() {
-  const router = useRouter();
   const { selected } = useReportHistory();
-  const [reportTitle, setReportTitle] = useState<string>("");
-  const [repositoryOverview, setRepositoryOverview] = useState<string>("");
-  const [isSubmitting, setIsSubmitting] = useState(false);
-  const [errorText, setErrorText] = useState<string | null>(null);
-  const [badRequestMessage, setBadRequestMessage] = useState<string | null>(
-    null,
+  const [state, formAction] = useActionState<ReportFormState, FormData>(
+    submitReportAction,
+    undefined,
   );
-
-  useEffect(() => {
-    const syncedTitle = selected?.reportTitle ?? "";
-    const syncedOverview = selected?.repositoryOverview ?? "";
-
-    setReportTitle(syncedTitle);
-    setRepositoryOverview(syncedOverview);
-  }, [selected]);
-
-  const handleSubmit: React.FormEventHandler<HTMLFormElement> = async (e) => {
-    e.preventDefault();
-    if (isSubmitting) return;
-    if (badRequestMessage) return;
-
-    try {
-      setErrorText(null);
-      setIsSubmitting(true);
-
-      const formData = new FormData(e.currentTarget);
-
-      const data = {
-        reportTitle: String(formData.get("reportTitle") || "").trim(),
-        repositoryOverview: String(
-          formData.get("repositoryOverview") || "",
-        ).trim(),
-        repositoryUrl: String(formData.get("repositoryUrl") || "").trim(),
-        branch: String(formData.get("branch") || "").trim(),
-        reportHistoryId: selected?.reportHistoryId ?? null,
-      };
-
-      if (data.reportTitle.length > 20) {
-        setBadRequestMessage(
-          VALIDATION_ERROR_MESSAGES.REPORT_INPUT.TITLE_MAX_LENGTH,
-        );
-        return;
-      }
-
-      if (data.repositoryOverview.length > 1000) {
-        setBadRequestMessage(
-          VALIDATION_ERROR_MESSAGES.REPORT_INPUT.REPOSITORY_OVERVIEW_MAX_LENGTH,
-        );
-        return;
-      }
-
-      if (!data.repositoryUrl || !data.branch) {
-        setErrorText("리포지토리 URL과 브랜치를 모두 선택해 주세요.");
-        setIsSubmitting(false);
-        return;
-      }
-
-      router.push("/loading");
-
-      const response = await fetch("/api/reports", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(data),
-      });
-
-      const resultData = await response.json();
-      const status = response.status;
-      const responseError =
-        resultData?.error?.message ?? "요청에 실패했습니다.";
-
-      if (!response.ok) {
-        setIsSubmitting(false);
-        handleApiError(router, status, responseError);
-        return;
-      }
-
-      const { result } = resultData;
-      const id = crypto.randomUUID();
-      sessionStorage.setItem(`guest:report:${id}`, JSON.stringify(result));
-
-      router.replace(`/report-view/${id}`);
-    } catch {
-      setErrorText(SYSTEM_ERROR_MESSAGES.NETWORK);
-      setIsSubmitting(false);
-    }
-  };
 
   return (
     <form
-      onSubmit={handleSubmit}
+      key={selected?.reportHistoryId ?? "empty"}
+      action={formAction}
       className="mx-auto mb-14 flex w-full max-w-3xl flex-col gap-12 rounded-xl bg-white p-10 pt-20 pb-32"
     >
-      <fieldset disabled={isSubmitting} className="contents">
-        <RepositoryBranchSelector />
-
-        <InputField
-          id="reportTitle"
-          name={"reportTitle"}
-          label={"리포트명"}
-          placeholder={"생성할 리포트명을 입력해 주세요."}
-          value={reportTitle}
-          onChange={(e) => setReportTitle(e.target.value)}
-        />
-        <div className="grid gap-3">
-          <Label className="text-base font-medium text-neutral-800">
-            리포지토리 개요
-          </Label>
-          <Textarea
-            value={repositoryOverview}
-            name="repositoryOverview"
-            className="min-h-[140px] rounded-lg border border-neutral-200 bg-white px-4 py-3 text-base text-neutral-900 placeholder:text-neutral-400 focus:border-sky-400 focus:ring-2 focus:ring-sky-100 focus:outline-none"
-            placeholder={`예시: 이 과제는 GitHub API를 활용해 저장소 브랜치와 커밋 내역을 조회하는 기능을 구현하는 과제입니다.\n예시: 주된 목적은 API 연동과 비동기 처리 역량을 확인하는 것입니다.`}
-            onChange={(e) => setRepositoryOverview(e.target.value)}
-          />
-        </div>
-
-        <div className="right-0 bottom-0 left-0 z-0 bg-white pt-5">
-          <div className="mx-auto max-w-3xl">
-            <Button
-              type="submit"
-              className="h-12 w-full rounded-lg bg-neutral-900 text-base font-semibold text-white shadow-sm hover:bg-neutral-600 focus:ring-2 focus:ring-neutral-200 focus:outline-none disabled:pointer-events-none disabled:opacity-50"
-            >
-              {isSubmitting ? "리포트 생성 요청 중..." : "리포트 생성"}
-            </Button>
-
-            {errorText && (
-              <ErrorMessage
-                className="pt-2 whitespace-normal"
-                message={errorText}
-              />
-            )}
-          </div>
-        </div>
-      </fieldset>
-
-      <AlertModal
-        open={!!badRequestMessage}
-        title="입력을 수정해 주세요!"
-        description={badRequestMessage || SYSTEM_ERROR_MESSAGES.NETWORK}
-        cancelLabel="닫기"
-        onCancel={() => {
-          setBadRequestMessage(null);
-          setIsSubmitting(false);
-        }}
+      <input
+        type="hidden"
+        name="reportHistoryId"
+        value={selected?.reportHistoryId ?? ""}
       />
+
+      <RepositoryBranchSelector />
+
+      <InputField
+        id="reportTitle"
+        name="reportTitle"
+        label="리포트 제목"
+        placeholder="생성할 리포트 제목을 입력해 주세요."
+        defaultValue={selected?.reportTitle ?? ""}
+      />
+
+      <div className="grid gap-3">
+        <Label className="text-base font-medium text-neutral-800">
+          리포지토리 개요
+        </Label>
+        <Textarea
+          name="repositoryOverview"
+          className="min-h-[140px] rounded-lg border border-neutral-200 bg-white px-4 py-3 text-base text-neutral-900 placeholder:text-neutral-400 focus:border-sky-400 focus:ring-2 focus:ring-sky-100 focus:outline-none"
+          placeholder={`예시: 이 과제는 GitHub API를 활용해 저장소 브랜치와 커밋 내역을 조회하는 기능을 구현하는 과제입니다.\n예시: 주된 목적은 API 연동과 비동기 처리 역량을 확인하는 것입니다.`}
+          defaultValue={selected?.repositoryOverview ?? ""}
+        />
+      </div>
+
+      <div className="right-0 bottom-0 left-0 z-0 bg-white pt-5">
+        <div className="mx-auto max-w-3xl">
+          <SubmitButton />
+          {state?.ok === false && state.formError && (
+            <ErrorMessage
+              className="pt-2 whitespace-normal"
+              message={state.formError}
+            />
+          )}
+        </div>
+      </div>
     </form>
   );
 }

--- a/src/app/ui/main/submit-button.tsx
+++ b/src/app/ui/main/submit-button.tsx
@@ -1,0 +1,18 @@
+import { useFormStatus } from "react-dom";
+import { Button } from "@/app/ui/common/button";
+
+function SubmitButton() {
+  const { pending } = useFormStatus();
+
+  return (
+    <Button
+      type="submit"
+      className="h-12 w-full rounded-lg bg-neutral-900 text-base font-semibold text-white shadow-sm hover:bg-neutral-600 focus:ring-2 focus:ring-neutral-200 focus:outline-none disabled:pointer-events-none disabled:opacity-50"
+      disabled={pending}
+    >
+      {pending ? "리포트 생성 요청 중..." : "리포트 생성"}
+    </Button>
+  );
+}
+
+export default SubmitButton;

--- a/src/types/report.ts
+++ b/src/types/report.ts
@@ -1,5 +1,7 @@
 import { CommitDetail } from "./commit";
 
+type ReportFormState = undefined | { ok: false; formError: string };
+
 interface ReportData {
   reportId?: string;
   reportTitle: string;
@@ -10,4 +12,4 @@ interface ReportData {
   branch: string;
 }
 
-export type { ReportData };
+export type { ReportData, ReportFormState };


### PR DESCRIPTION
## 📝 요약(Summary)
- **리포트 폼 제출 로직을 Server Action으로 전환**하여 클라이언트 fetch/상태 관리 복잡도 낮춤
- **응답의 jobId를 쿠키(jobId)에 저장**하고 /loading으로 리다이렉트하도록 변경
- `RepositoryBranchSelector`의 불필요한 상태를 정리* 및 **폼에서 값만 읽어오는 방식**으로 불필요한 리렌더링 방지
- 브랜치 선택 컴포넌트는 shadcn 기반 커스텀 UI라 폼 제출 시 값이 자동으로 포함되지 않아, 선택한 값을 `hidden input`에 동기화해 서버 액션으로 전달되도록 처리
- 리포지토리 URL/브랜치 미선택 시 에러 메세지 표시 및 서버 요청 차단


<br><br>

## ☑️ Task

- **ReportForm를 Server Action 기반 제출로 리팩토링**
    - useActionState 도입, `<form action={formAction}>`로 전환
    - 클라이언트 컴포넌트 내 fetch 제거, 서버 액션에서 `/api/reports` 호출
    
      <br>
      
- **jobId 쿠키 저장 및 리다이렉트**
    - `cookies().set('jobId', jobId, { path: '/loading', httpOnly: true, sameSite: 'lax', secure: true, maxAge: 300 })`
    - `redirect('/loading')` 처리
   
 <br>
      
- **`RepositoryBranchSelector` 리팩토링**
    - 불필요한 상태 제거로 리렌더링 최소화
    - URL은 입력값 그대로 사용하고, 브랜치 선택은 hidden input으로 서버 액션에 전달
    - 에러 메시지와 콤보박스 영역은 고정 높이로 UX 안정성 확보

<br>
          
- **폼 제출 사전 검증 보완** 
   - URL/브랜치 미선택 시 서버 액션까지 호출하지 않고 즉시 사용자에게 에러 메시지 표시
   
  
  <br><br>

## 💬 공유사항 to 리뷰어
1. `submitReportAction`의 첫 번째 인자인 `prevState`는 현재 코드에서 사용되진 않지만, 혼동이 있을 수 있어 공유합니다
   - `useActionState` 훅이 서버 액션을 호출할 때 항상 `(prevState, formData)` 형태로 인자를 넘기기 때문에, 반드시 받아야 하는 인자입니다!
   - `prevState`: 이전 액션 실행 후 리턴된 상태값
   - `formData`: 현재 폼에서 제출된 입력 값들을 담은 FormData 객체
   -  참고: (React 공식 문서) [useActionState](https://react.dev/reference/react/useActionState)

<br>

2. `/app/(with-layout)/actions/submit-report-action.ts` 위치에 대한 고민 공유
   - 리포트 제출 액션은 해당 페이지 전용 액션이고, **폼 입력 → API 호출 → 쿠키 세팅 → 리다이렉트**까지 화면 흐름에 강하게 결합되어 있어 UI 근처에 두는 것이 자연스럽다고 판단했습니다.
   - Next.js 공식 문서에서도 컴포넌트와 같은 위치에 액션을 두는 예시가 있어서, UI 근처에 두는 방식도 사용되는 패턴이라고 생각이 들었습니다! (공식 문서 예시: [Server Actions and Mutations](https://nextjs.org/docs/app/building-your-application/data-fetching/server-actions-and-mutations))
   - 서비스 계층(`services/`)은 도메인 규칙이나 비즈니스 로직을 모아두는 곳인데, 이번에 추가하게 된 액션은 `cookies()`, `redirect()`, `fetch()`처럼 **API 호출, 화면 제어 로직** 등이 포함되어 있어 서비스 계층에 적절하지 않다고 생각했습니다.
   - `lib/`은 공통 유틸이나 파서, 검증 함수처럼 프레임워크와 무관하게 재사용 가능한 코드를 두기 위한 곳이라 액션을 넣는 것은 맞지 않다고 판단했습니다.
   - 따라서 지금처럼 UI와 가까운 디렉토리에 배치하는 쪽이 맥락 파악과 리팩토링에도 유리하다고 생각했는데, 팀원들의 의견도 듣고 싶어 공유합니다!



<br><br>

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
- [ ] conflict를 모두 해결하였습니다.
- [ ] 가장 최신 dev 브랜치를 pull 하였습니다.
- [ ] 코드 컨벤션을 모두 확인하였습니다.
- [ ] `console.log`나 주석 여부를 확인하였습니다.
- [ ] 브랜치명을 확인하였습니다.
- [ ] 작업 중 dependency 변경사항이 있는 경우 안내해주세요!
